### PR TITLE
Add setup.py to make mincemeat pip-installable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+from distutils.core import setup
+setup(
+    name='mincemeat',
+    version='0.1.2',
+    author='Michael Fairley',
+    py_modules=['mincemeat'],
+    scripts=['mincemeat.py'],
+    install_requires=[],
+)


### PR DESCRIPTION
We talked a few weeks ago about some tweaks I've been playing with in mincemeat.  This (just adding a setup.py file) is the simpler and less-controversial addition, so it's in its own pull request.  I'll submit the rest of the stuff as a separate request either later today or tomorrow.  Sorry it took me so long to get around to this.
