### PR TITLE
Remove reference to cPickle for Python 3 comptability

### DIFF
--- a/mincemeat.py
+++ b/mincemeat.py
@@ -25,7 +25,7 @@
 
 import asynchat
 import asyncore
-import cPickle as pickle
+import pickle
 import hashlib
 import hmac
 import logging


### PR DESCRIPTION
pickle module in Python 3 uses C version where available: http://docs.python.org/3.3/whatsnew/3.0.html?highlight=cpickle
