### PR TITLE
Update mincemeat.py

### DIFF
--- a/mincemeat.py
+++ b/mincemeat.py
@@ -35,7 +35,7 @@ import logging
 import argparse
 import asynchat
 import asyncore
-import cPickle as pickle
+import pickle
 
 
 VERSION = "0.1.4"


### PR DESCRIPTION
There is no cPickle in Python 3. Just import pickle. pickle will automatically use the C accelerator.
https://stackoverflow.com/questions/49579282/cant-find-module-cpickle-using-python-3-5-and-anaconda